### PR TITLE
Add dual speaker attribution modes with role-based GPT input

### DIFF
--- a/gpt_speaker_attribution.py
+++ b/gpt_speaker_attribution.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import logging
+import argparse
 from typing import List, Dict
 
 try:
@@ -22,24 +23,88 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-def predict_speakers(client: OpenAI, speaker_a: str, speaker_b: str, lines: List[str]) -> Dict[str, str]:
-    """Ask a GPT model to predict which speaker spoke each line, with logging."""
-    conversation = "\n".join(f"{i+1}. {line}" for i, line in enumerate(lines))
-    prompt = (
-        f"Given a conversation between two speakers: {speaker_a} and {speaker_b}.\n"
-        f"Each line is numbered but speaker names are hidden.\n"
-        f"Return a JSON object mapping line numbers (as strings) to the speaker who said it.\n\n"
-        f"Conversation:\n{conversation}\n"
+def predict_speakers(
+    client: OpenAI,
+    speaker_a: str,
+    speaker_b: str,
+    turns: List[Dict[str, str]],
+    conv_idx: int,
+    session_idx: int,
+    hide_names: bool,
+) -> Dict[str, str]:
+    """Ask a GPT model to predict which speaker spoke each line, with logging.
+
+    Parameters
+    ----------
+    client: OpenAI
+        The OpenAI client used for generation.
+    speaker_a, speaker_b: str
+        The two participant names.
+    turns: List[Dict[str, str]]
+        Conversation turns in order.
+    conv_idx, session_idx: int
+        Identifiers for logging.
+    hide_names: bool
+        Whether to hide speaker names in the prompt.
+    """
+
+    messages: List[Dict[str, str]] = []
+
+    if hide_names:
+        system_msg = (
+            "You will be given a conversation between two speakers: "
+            f"{speaker_a} and {speaker_b}. The conversation messages use the "
+            "placeholder roles 'Speaker 1' and 'Speaker 2'. The first message "
+            "after this system prompt is message 1, the next is message 2, and "
+            "so on. Determine which real speaker said each message and return a "
+            "JSON object mapping message numbers (as strings) to the speaker's "
+            "name."
+        )
+        messages.append({"role": "system", "content": system_msg})
+
+        for turn in turns:
+            placeholder = "Speaker 1" if turn["speaker"] == speaker_a else "Speaker 2"
+            messages.append({"role": placeholder, "content": turn["text"]})
+    else:
+        system_msg = (
+            "You will be given a conversation between two speakers. Each "
+            "message's role is the speaker's name. The first message after this "
+            "system prompt is message 1, the next is message 2, and so on. "
+            "Return a JSON object mapping message numbers (as strings) to the "
+            "speaker's name."
+        )
+        messages.append({"role": "system", "content": system_msg})
+
+        for turn in turns:
+            messages.append({"role": turn["speaker"], "content": turn["text"]})
+
+    messages.append(
+        {
+            "role": "user",
+            "content": "Respond with the JSON mapping now.",
+        }
     )
 
-    # Log the input prompt
-    logger.info("========== GPT INPUT ==========\n%s", prompt)
+    version = "hidden" if hide_names else "names"
 
-    response = client.responses.create(model="gpt-4o-mini", input=prompt)
+    logger.info(
+        "Conversation %d Session %d (%s) GPT INPUT:\n%s",
+        conv_idx,
+        session_idx,
+        version,
+        json.dumps(messages, ensure_ascii=False, indent=2),
+    )
+
+    response = client.responses.create(model="gpt-4o-mini", input=messages)
     text = response.output_text.strip()
 
-    # Log the raw output
-    logger.info("========== GPT OUTPUT ==========\n%s", text)
+    logger.info(
+        "Conversation %d Session %d (%s) GPT OUTPUT:\n%s",
+        conv_idx,
+        session_idx,
+        version,
+        text,
+    )
 
     try:
         return json.loads(text)
@@ -53,13 +118,30 @@ def predict_speakers(client: OpenAI, speaker_a: str, speaker_b: str, lines: List
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Evaluate GPT speaker attribution accuracy"
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["hidden", "names", "both"],
+        default="both",
+        help="Hide speaker names, show them, or evaluate both modes",
+    )
+    args = parser.parse_args()
+    mode = args.mode
+
     with open("data/locomo10.json", "r", encoding="utf-8") as f:
         dataset = json.load(f)
 
     client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
-    total_correct = 0
-    total_lines = 0
+    total_correct_hidden = 0
+    total_lines_hidden = 0
+    total_correct_names = 0
+    total_lines_names = 0
+
+    results_hidden: Dict[str, Dict[str, Dict[str, object]]] = {}
+    results_names: Dict[str, Dict[str, Dict[str, object]]] = {}
 
     for conv_idx, sample in enumerate(dataset, start=1):
         conv = sample["conversation"]
@@ -75,22 +157,99 @@ def main() -> None:
             if not session_data:
                 continue
 
-            lines = [turn["text"] for turn in session_data]
             gold = [turn["speaker"] for turn in session_data]
 
-            prediction = predict_speakers(client, speaker_a, speaker_b, lines)
-            correct = sum(
-                1 for i, spk in enumerate(gold, start=1) if prediction.get(str(i)) == spk
-            )
-            accuracy = correct / len(gold) if gold else 0
-            total_correct += correct
-            total_lines += len(gold)
-            print(
-                f"Conversation {conv_idx} Session {session_idx}: {accuracy:.2%} accuracy"
-            )
+            if mode in ("hidden", "both"):
+                prediction_hidden = predict_speakers(
+                    client,
+                    speaker_a,
+                    speaker_b,
+                    session_data,
+                    conv_idx,
+                    session_idx,
+                    hide_names=True,
+                )
+                correct_hidden = sum(
+                    1 for i, spk in enumerate(gold, start=1)
+                    if prediction_hidden.get(str(i)) == spk
+                )
+                accuracy_hidden = correct_hidden / len(gold) if gold else 0
+                total_correct_hidden += correct_hidden
+                total_lines_hidden += len(gold)
+                line_hidden = (
+                    f"Conversation {conv_idx} Session {session_idx} (hidden): {accuracy_hidden:.2%} accuracy"
+                )
+                print(line_hidden)
 
-    overall = total_correct / total_lines if total_lines else 0
-    print(f"Overall accuracy across all sessions: {overall:.2%}")
+                conv_key = f"conversation{conv_idx}"
+                sess_key = f"session{session_idx}"
+                results_hidden.setdefault(conv_key, {})[sess_key] = {
+                    "answers": gold,
+                    "predict": [
+                        prediction_hidden.get(str(i), "")
+                        for i in range(1, len(gold) + 1)
+                    ],
+                    "accuracy": accuracy_hidden,
+                }
+
+            if mode in ("names", "both"):
+                prediction_names = predict_speakers(
+                    client,
+                    speaker_a,
+                    speaker_b,
+                    session_data,
+                    conv_idx,
+                    session_idx,
+                    hide_names=False,
+                )
+                correct_names = sum(
+                    1 for i, spk in enumerate(gold, start=1)
+                    if prediction_names.get(str(i)) == spk
+                )
+                accuracy_names = correct_names / len(gold) if gold else 0
+                total_correct_names += correct_names
+                total_lines_names += len(gold)
+                line_names = (
+                    f"Conversation {conv_idx} Session {session_idx} (names): {accuracy_names:.2%} accuracy"
+                )
+                print(line_names)
+
+                conv_key = f"conversation{conv_idx}"
+                sess_key = f"session{session_idx}"
+                results_names.setdefault(conv_key, {})[sess_key] = {
+                    "answers": gold,
+                    "predict": [
+                        prediction_names.get(str(i), "")
+                        for i in range(1, len(gold) + 1)
+                    ],
+                    "accuracy": accuracy_names,
+                }
+
+    if mode in ("hidden", "both"):
+        overall_hidden = (
+            total_correct_hidden / total_lines_hidden if total_lines_hidden else 0
+        )
+        summary_hidden = (
+            f"Overall accuracy across all sessions (hidden): {overall_hidden:.2%}"
+        )
+        print(summary_hidden)
+        results_hidden["overall_accuracy"] = overall_hidden
+
+        with open("outputs_hidden.json", "w", encoding="utf-8") as f_out:
+            json.dump(results_hidden, f_out, ensure_ascii=False, indent=2)
+
+    if mode in ("names", "both"):
+        overall_names = (
+            total_correct_names / total_lines_names if total_lines_names else 0
+        )
+        summary_names = (
+            f"Overall accuracy across all sessions (names): {overall_names:.2%}"
+        )
+        print(summary_names)
+        results_names["overall_accuracy"] = overall_names
+
+        with open("outputs_names.json", "w", encoding="utf-8") as f_out:
+            json.dump(results_names, f_out, ensure_ascii=False, indent=2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Support speaker attribution with optional `--mode` flag to run hidden names, visible names, or both
- Send conversations as chat messages where each utterance's role is the speaker's name or a placeholder, matching the expected model input format, and log the structured messages
- Record per-session answers, predictions, and accuracy in nested JSON files for each mode, along with overall accuracy summaries

## Testing
- `python -m py_compile gpt_speaker_attribution.py`


------
https://chatgpt.com/codex/tasks/task_e_68b52f6fa61083228110d49a5f404f2c